### PR TITLE
Update SOPS configuration

### DIFF
--- a/.security/risc/.sops.yaml
+++ b/.security/risc/.sops.yaml
@@ -1,0 +1,13 @@
+---
+creation_rules:
+- path_regex: "\\.risc\\.yaml$"
+  shamir_threshold: 2
+  key_groups:
+  - age:
+    - "age145s860ux96jvx6d7nwvzar588qjmgv5p47sp6nmmt2jnmhqh4scqcuk0mg"
+    gcp_kms:
+    - resource_id: "projects/skvis-prod-9329/locations/europe-north1/keyRings/skvis-risc-key-ring/cryptoKeys/skvis-risc-crypto-key"
+  - age:
+    - "age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23"
+    - "age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq"
+  - age: []


### PR DESCRIPTION
This pull request updates the SOPS configuration that is needed to encrypt and decrypt RiSc's in [Risk Scorecard in Kartverket.dev](https://kartverket.dev/catalog/default/component/initialize-risc-api/risc). Merge this PR in order to use the new SOPS configuration in the [Risk Scorecard plugin](https://kartverket.dev/catalog/default/component/initialize-risc-api/risc).