### PR TITLE
Update SOPS configuration

### DIFF
--- a/.security/risc/.sops.yaml
+++ b/.security/risc/.sops.yaml
@@ -9,3 +9,5 @@ creation_rules:
   - age:
     - "age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23"
     - "age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq"
+  - age:
+    - "age1n5f3mvpjeceeq3gc9hj77qdnhuxjnaqhd7lsf6qdtv9m3d6a450sxggc36"


### PR DESCRIPTION
This pull request updates the SOPS configuration that is needed to encrypt and decrypt RiSc's in [Risk Scorecard in Kartverket.dev](https://kartverket.dev/catalog/default/component/initialize-risc-api/risc). Merge this PR in order to use the new SOPS configuration in the [Risk Scorecard plugin](https://kartverket.dev/catalog/default/component/initialize-risc-api/risc).