### PR TITLE
Endepunktstester for generate/{repositoryName}

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ val logbackVersion = "1.5.18"
 val jacksonVersion = "2.18.3"
 val nettyHandlerVersion = "4.1.119.Final"
 val junitVersion = "5.12.2"
+val mockkVersion = "1.14.0"
 
 plugins {
     kotlin("jvm") version "2.1.20"
@@ -50,7 +51,6 @@ dependencies {
 
     testImplementation("io.ktor:ktor-server-test-host-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 
     testImplementation(platform("org.junit:junit-bom:$junitVersion")) {
         because("The BOM (bill of materials) provides correct versions for all JUnit libraries used.")
@@ -58,7 +58,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    testImplementation("io.mockk:mockk:1.14.0")
+    testImplementation("io.mockk:mockk:$mockkVersion")
 }
 
 tasks.test {

--- a/src/test/kotlin/kartverket/no/generate/GenerateRiScRoutesTest.kt
+++ b/src/test/kotlin/kartverket/no/generate/GenerateRiScRoutesTest.kt
@@ -16,7 +16,6 @@ import kartverket.no.airTable.AirTableClientService
 import kartverket.no.config.AppConfig
 import kartverket.no.generate.model.GenerateRiScRequestBody
 import kartverket.no.generate.model.RiScContent
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach


### PR DESCRIPTION
### **Lagt til endepunktstester for generate/{repositoryName}:**

**Happy path:**

- Returnerer 200 OK med forventet RiScContent når input er gyldig og Airtable-kallet lykkes (mocket i test).

**Feilhåndtering:**

- Returnerer 400 Bad Request hvis initialRiSc-feltet:
1. ikke er gyldig JSON
2. mangler obligatoriske felter (title eller scope)

- Returnerer 404 Not Found hvis repositoryName ikke er oppgitt i URL

Testene bruker MockK til å mocke AirTableClientService, slik at testene kun validerer endepunktlogikken
