### PR TITLE
Fiks miljøvariabelsyntaks i application.yaml for Ktor

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,12 +7,12 @@ ktor:
 
 generateRiSc:
   pathRegex: '\.risc\.yaml$'
-  backendPublicKey: ${BACKEND_PUBLIC_KEY}
-  securityPlatformPublicKey: ${SECURITY_PLATFORM_PUBLIC_KEY}
-  securityTeamPublicKey: ${SECURITY_TEAM_PUBLIC_KEY}
+  backendPublicKey: $BACKEND_PUBLIC_KEY
+  securityPlatformPublicKey: $SECURITY_PLATFORM_PUBLIC_KEY
+  securityTeamPublicKey: $SECURITY_TEAM_PUBLIC_KEY
 
 airTable:
   baseUrl: 'https://api.airtable.com'
-  baseId: ${AIRTABLE_BASE_ID}
-  apiToken: ${AIRTABLE_API_TOKEN}
-  recordId: ${AIRTABLE_RECORD_ID}
+  baseId: $AIRTABLE_BASE_ID
+  apiToken: $AIRTABLE_API_TOKEN
+  recordId: $AIRTABLE_RECORD_ID


### PR DESCRIPTION
Fjerner ${...} rundt miljøvariabler i application.yaml, da Ktor sin YAML-parser forventer variabler i formen "$VAR" og ikke "${VAR}".

Dette førte til runtime-feil med "Char sequence is empty" under oppstart selv om variabler var korrekt satt i .env.