### PR TITLE
Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Maintain dependencies for Gradle
+  - package-ecosystem: "gradle"
+    open-pull-requests-limit: 10
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/.github/"
+    schedule:
+      interval: "weekly"
+  # Maintain docker images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Setups up Dependabot for dependency update monitoring. Uses the same setup as in [kartverket/backstage-plu…gin-risk-scorecard-backend](https://github.com/kartverket/backstage-plugin-risk-scorecard-backend/blob/main/.github/dependabot.yml).