### PR TITLE
Only run Pharos when the pull request is ready for review.

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -123,6 +123,7 @@ jobs:
 
   pharos:
     name: Run Pharos on docker image
+    if: ${{ !github.event.pull_request.draft }}
     needs: build
     permissions:
       actions: read


### PR DESCRIPTION
Fixes an issue in which the Pharos workflow would crash for draft PRs, as draft PRs are configured to not push Docker containers in the build stage. This PR turns the Pharos workflow off for draft PRs, but runs the Pharos workflow automatically when the PR is marked as `ready for review`.