### PR TITLE
Use table ID instead of name for the AirTable table to retreive the default RiSc from.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 AIRTABLE_BASE_ID=
 AIRTABLE_API_TOKEN=
 AIRTABLE_RECORD_ID=
+AIRTABLE_TABLE_ID=
 
 # === Public keys brukt i RiSc-generering (påkrevd) ===
 SECURITY_TEAM_PUBLIC_KEY=

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 ## Run the application
 `intialize-risc-api` needs some environment variables to be runned.
 
-| Env var                        | Description                                                                 | Required? |
-|-------------------------------|-----------------------------------------------------------------------------|-----------|
-| AIRTABLE_API_TOKEN            | API token used to authenticate requests to the Airtable API.               | ✅         |
-| AIRTABLE_BASE_ID              | Identifier for the specific Airtable base being accessed.                  | ✅         |
-| AIRTABLE_RECORD_ID            | ID of a particular record in the Airtable base.                            | ✅         |
-| SECURITY_TEAM_PUBLIC_KEY      | Public key for encryption used by the security team.                       | ✅         |
-| SECURITY_PLATFORM_PUBLIC_KEY  | Public key for encryption used by the platform.                            | ✅         |
-| BACKEND_PUBLIC_KEY            | Public key for backend encryption.                                         | ✅         |
+| Env var                      | Description                                                  | Required? |
+|------------------------------|--------------------------------------------------------------|-----------|
+| AIRTABLE_API_TOKEN           | API token used to authenticate requests to the Airtable API. | ✅         |
+| AIRTABLE_BASE_ID             | Identifier for the specific Airtable base being accessed.    | ✅         |
+| AIRTABLE_RECORD_ID           | ID of a particular record in the Airtable base.              | ✅         |
+| AIRTABLE_TABLE_ID            | ID of a particular table in the Airtable base.               | ✅         |
+| SECURITY_TEAM_PUBLIC_KEY     | Public key for encryption used by the security team.         | ✅         |
+| SECURITY_PLATFORM_PUBLIC_KEY | Public key for encryption used by the platform.              | ✅         |
+| BACKEND_PUBLIC_KEY           | Public key for backend encryption.                           | ✅         |
 
 ---
 

--- a/src/main/kotlin/kartverket/no/Application.kt
+++ b/src/main/kotlin/kartverket/no/Application.kt
@@ -68,6 +68,11 @@ private fun loadConfig(
                     fullPath = "$path.recordId",
                     logger = logger,
                 )
+            tableId = config.propertyOrNull("$path.tableId")?.getString()
+                ?: throw AppConfigInitializationException(
+                    fullPath = "$path.tableId",
+                    logger = logger,
+                )
         }
 }
 

--- a/src/main/kotlin/kartverket/no/airTable/AirTableClientService.kt
+++ b/src/main/kotlin/kartverket/no/airTable/AirTableClientService.kt
@@ -30,7 +30,7 @@ object AirTableClientService {
     suspend fun fetchDefaultRiSc() =
         json.decodeFromString<RiScContent>(
             fetch<AirTableFetchRecordsResponse>(
-                path = "v0/${config.baseId}/RoS",
+                path = "v0/${config.baseId}/${config.tableId}",
                 queryParams = mapOf("view" to "RoS-Json"),
             ).toRiScContentString(logger, config.recordId),
         )

--- a/src/main/kotlin/kartverket/no/config/AppConfig.kt
+++ b/src/main/kotlin/kartverket/no/config/AppConfig.kt
@@ -11,6 +11,7 @@ object AirTableConfig {
     lateinit var baseId: String
     lateinit var apiToken: String
     lateinit var recordId: String
+    lateinit var tableId: String
 }
 
 object GenerateRiScConfig {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,3 +16,4 @@ airTable:
   baseId: $AIRTABLE_BASE_ID
   apiToken: $AIRTABLE_API_TOKEN
   recordId: $AIRTABLE_RECORD_ID
+  tableId: $AIRTABLE_TABLE_ID


### PR DESCRIPTION
Makes `tableId` a modifiable environment variable.