### PR TITLE
Specify that version 1.6.0 of Ktlint should be used.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,12 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
 }
 
+// Specifies the usage of the currently newest version of Ktlint. `org.jlleitschuh.gradle.ktlint` version 12.2.0 is
+// not guaranteed to use the newest version available.
+ktlint {
+    version.set("1.6.0")
+}
+
 group = "kartverket.no"
 version = "0.0.1"
 


### PR DESCRIPTION
Specifies that version 1.6.0 of Ktlint should be used. Otherwise `org.jlleitschuh.gradle.ktlint` defaults to a much older version. This fixes open security alerts [1](https://github.com/kartverket/initialize-risc-api/security/dependabot/1), [2](https://github.com/kartverket/initialize-risc-api/security/dependabot/2), [5](https://github.com/kartverket/initialize-risc-api/security/dependabot/5) and [7](https://github.com/kartverket/initialize-risc-api/security/dependabot/7).