### PR TITLE
Added functionality for fetching data about default riscs from Airtable

### DIFF
--- a/src/main/kotlin/kartverket/no/airTable/AirTableClientService.kt
+++ b/src/main/kotlin/kartverket/no/airTable/AirTableClientService.kt
@@ -34,7 +34,7 @@ object AirTableClientService {
             }
         }
 
-    private suspend fun fetchDefaultRiScsFromAirTable(): AirTableFetchRecordsResponse =
+    suspend fun fetchDefaultRiScsFromAirTable(): AirTableFetchRecordsResponse =
         fetch<AirTableFetchRecordsResponse>(
             path = "v0/${config.baseId}/${config.tableId}",
         )

--- a/src/main/kotlin/kartverket/no/airTable/model/DTOs.kt
+++ b/src/main/kotlin/kartverket/no/airTable/model/DTOs.kt
@@ -1,6 +1,9 @@
 package kartverket.no.airTable.model
 
+import kartverket.no.descriptor.model.RiScDescriptor
 import kartverket.no.exception.exceptions.RetrieveDefaultRiScContentFromAirTableFetchRecordsResponseException
+import kartverket.no.generate.model.DefaultRiScType
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.slf4j.Logger
 
@@ -31,3 +34,33 @@ data class AirTableRecord(
 data class AirTableFields(
     val rosJson: String,
 )
+
+@Serializable
+data class AirTableFetchRecordsResponseOnlyMetadata(
+    val records: List<AirTableRecordOnlyMetadata>,
+)
+
+@Serializable
+data class AirTableRecordOnlyMetadata(
+    val id: String,
+    val fields: AirTableFieldsOnlyMetadata,
+)
+
+@Serializable
+data class AirTableFieldsOnlyMetadata(
+    @SerialName("List-name") val listName: String? = null,
+    @SerialName("List-description") val listDescription: String? = null,
+    @SerialName("Title") val defaultTitle: String? = null,
+    @SerialName("Scope") val defaultScope: String? = null,
+    @SerialName("Antall scenarier") val numberOfScenarios: Int? = null,
+    @SerialName("Antall tiltak") val numberOfActions: Int? = null,
+) {
+    fun toRiScDescriptor(defaultRiScType: DefaultRiScType): RiScDescriptor =
+        RiScDescriptor(
+            riScType = defaultRiScType,
+            listName = listName ?: "Unknown name",
+            listDescription = listDescription ?: "Unknown description",
+            defaultTitle = defaultTitle ?: "",
+            defaultScope = defaultScope ?: "",
+        )
+}

--- a/src/main/kotlin/kartverket/no/airTable/model/DTOs.kt
+++ b/src/main/kotlin/kartverket/no/airTable/model/DTOs.kt
@@ -39,8 +39,8 @@ data class AirTableFields(
     fun toRiScDescriptor(defaultRiScType: DefaultRiScType): RiScDescriptor =
         RiScDescriptor(
             riScType = defaultRiScType,
-            listName = listName ?: "Unknown name",
-            listDescription = listDescription ?: "Unknown description",
+            listName = listName ?: defaultRiScType.name,
+            listDescription = listDescription ?: "",
             defaultTitle = defaultTitle ?: "",
             defaultScope = defaultScope ?: "",
             numberOfScenarios = numberOfScenarios,

--- a/src/main/kotlin/kartverket/no/descriptor/DescriptorRoutes.kt
+++ b/src/main/kotlin/kartverket/no/descriptor/DescriptorRoutes.kt
@@ -1,0 +1,14 @@
+package kartverket.no.descriptor
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+
+fun Route.descriptorRoutes() {
+    route("/descriptors") {
+        get {
+            val descriptors = DescriptorService.getAllRiScDescriptors()
+            call.respond(descriptors)
+        }
+    }
+}

--- a/src/main/kotlin/kartverket/no/descriptor/DescriptorService.kt
+++ b/src/main/kotlin/kartverket/no/descriptor/DescriptorService.kt
@@ -1,0 +1,14 @@
+package kartverket.no.descriptor
+
+import kartverket.no.airTable.AirTableClientService
+import kartverket.no.descriptor.model.RiScDescriptor
+import kartverket.no.utils.DefaultRiScTypeUtils
+
+object DescriptorService {
+    suspend fun getAllRiScDescriptors(): List<RiScDescriptor> {
+        val recordIds = DefaultRiScTypeUtils.getAllRecordIds()
+        return AirTableClientService.fetchDefaultRiScDescriptors(recordIds).map {
+            it.fields.toRiScDescriptor(DefaultRiScTypeUtils.getRiScTypeFromRecordId(it.id))
+        }
+    }
+}

--- a/src/main/kotlin/kartverket/no/descriptor/DescriptorService.kt
+++ b/src/main/kotlin/kartverket/no/descriptor/DescriptorService.kt
@@ -2,7 +2,6 @@ package kartverket.no.descriptor
 
 import kartverket.no.airTable.AirTableClientService
 import kartverket.no.descriptor.model.RiScDescriptor
-import kartverket.no.utils.DefaultRiScTypeUtils
 
 object DescriptorService {
     suspend fun getAllRiScDescriptors(): List<RiScDescriptor> {

--- a/src/main/kotlin/kartverket/no/descriptor/DescriptorService.kt
+++ b/src/main/kotlin/kartverket/no/descriptor/DescriptorService.kt
@@ -6,9 +6,7 @@ import kartverket.no.utils.DefaultRiScTypeUtils
 
 object DescriptorService {
     suspend fun getAllRiScDescriptors(): List<RiScDescriptor> {
-        val recordIds = DefaultRiScTypeUtils.getAllRecordIds()
-        return AirTableClientService.fetchDefaultRiScDescriptors(recordIds).map {
-            it.fields.toRiScDescriptor(DefaultRiScTypeUtils.getRiScTypeFromRecordId(it.id))
-        }
+        val riScDescriptors = AirTableClientService.fetchDefaultRiScDescriptors()
+        return riScDescriptors
     }
 }

--- a/src/main/kotlin/kartverket/no/descriptor/model/RiScDescriptor.kt
+++ b/src/main/kotlin/kartverket/no/descriptor/model/RiScDescriptor.kt
@@ -1,0 +1,13 @@
+package kartverket.no.descriptor.model
+
+import kartverket.no.generate.model.DefaultRiScType
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RiScDescriptor(
+    val riScType: DefaultRiScType,
+    val listName: String,
+    val listDescription: String,
+    val defaultTitle: String,
+    val defaultScope: String,
+)

--- a/src/main/kotlin/kartverket/no/descriptor/model/RiScDescriptor.kt
+++ b/src/main/kotlin/kartverket/no/descriptor/model/RiScDescriptor.kt
@@ -10,4 +10,6 @@ data class RiScDescriptor(
     val listDescription: String,
     val defaultTitle: String,
     val defaultScope: String,
+    val numberOfScenarios: Int?,
+    val numberOfActions: Int?,
 )

--- a/src/main/kotlin/kartverket/no/exception/exceptions/AirTableEntityNotFoundException.kt
+++ b/src/main/kotlin/kartverket/no/exception/exceptions/AirTableEntityNotFoundException.kt
@@ -1,0 +1,12 @@
+package kartverket.no.exception.exceptions
+
+import org.slf4j.Logger
+
+data class AirTableEntityNotFoundException(
+    val logger: Logger,
+    override val message: String,
+) : Exception() {
+    init {
+        logger.error(message)
+    }
+}

--- a/src/main/kotlin/kartverket/no/generate/GenerateService.kt
+++ b/src/main/kotlin/kartverket/no/generate/GenerateService.kt
@@ -19,14 +19,14 @@ object GenerateService {
         defaultRiScTypes: List<DefaultRiScType>,
     ): String {
         // For now only a single default risc is fetched (The first risc in the defaultRiScs list)
-        val defaultRiScToFetch =
+        val defaultRiScType =
             if (defaultRiScTypes.isEmpty()) {
                 DefaultRiScType.Standard
             } else {
                 defaultRiScTypes[0]
             }
         return generateInitialRiScContent(
-            AirTableClientService.fetchDefaultRiSc(defaultRiScToFetch),
+            AirTableClientService.fetchDefaultRiScContent(defaultRiScType),
             initialRiScContent,
         ).content
     }

--- a/src/main/kotlin/kartverket/no/plugins/Routing.kt
+++ b/src/main/kotlin/kartverket/no/plugins/Routing.kt
@@ -5,6 +5,7 @@ import io.ktor.server.application.Application
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import kartverket.no.descriptor.descriptorRoutes
 import kartverket.no.generate.generateRiScRoutes
 
 fun Application.configureRouting() {
@@ -13,5 +14,6 @@ fun Application.configureRouting() {
             call.respondText("All good!", ContentType.Text.Plain)
         }
         generateRiScRoutes()
+        descriptorRoutes()
     }
 }

--- a/src/main/kotlin/kartverket/no/utils/DefaultRiScTypeUtils.kt
+++ b/src/main/kotlin/kartverket/no/utils/DefaultRiScTypeUtils.kt
@@ -1,0 +1,25 @@
+package kartverket.no.utils
+
+import kartverket.no.config.AppConfig
+import kartverket.no.generate.model.DefaultRiScType
+
+object DefaultRiScTypeUtils {
+    private val config = AppConfig.airTableConfig
+
+    fun getRecordIdFromRiScType(defaultRiScType: DefaultRiScType): String =
+        when (defaultRiScType) {
+            DefaultRiScType.Ops -> config.recordIdOps
+            DefaultRiScType.InternalJob -> config.recordIdInternalJob
+            DefaultRiScType.Standard -> config.recordIdStandard
+        }
+
+    fun getRiScTypeFromRecordId(recordId: String): DefaultRiScType =
+        when (recordId) {
+            config.recordIdOps -> DefaultRiScType.Ops
+            config.recordIdInternalJob -> DefaultRiScType.InternalJob
+            config.recordIdStandard -> DefaultRiScType.Standard
+            else -> DefaultRiScType.Standard
+        }
+
+    fun getAllRecordIds(): Set<String> = setOf(config.recordIdOps, config.recordIdInternalJob, config.recordIdStandard)
+}

--- a/src/test/kotlin/kartverket/no/airTable/AirTableClientServiceTest.kt
+++ b/src/test/kotlin/kartverket/no/airTable/AirTableClientServiceTest.kt
@@ -208,8 +208,8 @@ class AirTableClientServiceTest {
             assertEquals(1, descriptors.size)
             val eD = descriptors[0]
             assertEquals(eD.riScType, DefaultRiScType.Standard)
-            assertEquals(eD.listName, "Unknown name")
-            assertEquals(eD.listDescription, "Unknown description")
+            assertEquals(eD.listName, "Standard")
+            assertEquals(eD.listDescription, "")
             assertEquals(eD.defaultTitle, "")
             assertEquals(eD.defaultScope, "")
             assertEquals(eD.numberOfActions, null)

--- a/src/test/kotlin/kartverket/no/airTable/AirTableClientServiceTest.kt
+++ b/src/test/kotlin/kartverket/no/airTable/AirTableClientServiceTest.kt
@@ -1,0 +1,218 @@
+package kartverket.no.descriptor
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.spyk
+import kartverket.no.airTable.AirTableClientService
+import kartverket.no.airTable.model.AirTableFetchRecordsResponse
+import kartverket.no.airTable.model.AirTableFields
+import kartverket.no.airTable.model.AirTableRecord
+import kartverket.no.config.AppConfig
+import kartverket.no.generate.model.DefaultRiScType
+import kartverket.no.utils.DefaultRiScTypeUtils
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+
+class AirTableClientServiceTest {
+    val airTableRecordOps =
+        AirTableRecord(
+            id = "rec-ops",
+            fields =
+                AirTableFields(
+                    rosJson = "{}",
+                    listName = "Ops",
+                    listDescription = "An ops job",
+                    defaultTitle = "Initial RiSc - Ops",
+                    defaultScope = "RiSc generated for <ops>",
+                    numberOfScenarios = 3,
+                    numberOfActions = 22,
+                ),
+        )
+
+    val airTableRecordInternalJob =
+        AirTableRecord(
+            id = "rec-int",
+            fields =
+                AirTableFields(
+                    rosJson = "{}",
+                    listName = "Internal Job",
+                    listDescription = "An internal job",
+                    defaultTitle = "Initial RiSc - Internal Job",
+                    defaultScope = "RiSc generated for <internal job>",
+                    numberOfScenarios = 5,
+                    numberOfActions = 70,
+                ),
+        )
+
+    val airTableRecordStandard =
+        AirTableRecord(
+            id = "rec-sta",
+            fields =
+                AirTableFields(
+                    rosJson = "{}",
+                    listName = "Standard",
+                    listDescription = "A standard job",
+                    defaultTitle = "Initial RiSc - Standard",
+                    defaultScope = "RiSc generated for <standard>",
+                    numberOfScenarios = 2,
+                    numberOfActions = 4,
+                ),
+        )
+
+    val airTableRecordEmpty =
+        AirTableRecord(
+            id = "rec-sta",
+            fields = AirTableFields(),
+        )
+
+    val exampleAirtableFetchResponse =
+        AirTableFetchRecordsResponse(
+            records = listOf(airTableRecordOps, airTableRecordInternalJob, airTableRecordStandard),
+        )
+
+    val emptyAirtableFetchResponse =
+        AirTableFetchRecordsResponse(
+            records = listOf(airTableRecordEmpty),
+        )
+
+    @BeforeEach
+    fun setup() {
+        AppConfig.generateRiScConfig = kartverket.no.config.GenerateRiScConfig
+        AppConfig.airTableConfig = kartverket.no.config.AirTableConfig
+
+        with(AppConfig.generateRiScConfig) {
+            pathRegex = ".*"
+        }
+
+        with(AppConfig.airTableConfig) {
+            baseUrl = "https://dummy.airtable.com"
+            baseId = "dummyBaseId"
+            apiToken = "dummyToken"
+            recordIdOps = "rec-ops"
+            recordIdInternalJob = "rec-int"
+            recordIdStandard = "rec-sta"
+        }
+    }
+
+    @Test
+    fun `fetchDefaultRiScDescriptors filters out irrelevant riscs`() =
+        runTest {
+            val airTableClientService = spyk<AirTableClientService>()
+            mockkObject(DefaultRiScTypeUtils)
+
+            coEvery {
+                airTableClientService.fetchDefaultRiScsFromAirTable()
+            } returns exampleAirtableFetchResponse
+            every { DefaultRiScTypeUtils.getAllRecordIds() } returns setOf("rec-ops", "rec-int")
+
+            val descriptors = airTableClientService.fetchDefaultRiScDescriptors()
+
+            assertEquals(2, descriptors.size)
+
+            assertNotEquals(descriptors[0].listName, descriptors[1].listName)
+            assertTrue(airTableRecordOps.fields.listName in descriptors.map { it.listName })
+            assertTrue(airTableRecordInternalJob.fields.listName in descriptors.map { it.listName })
+            assertFalse(airTableRecordStandard.fields.listName in descriptors.map { it.listName })
+        }
+
+    @Test
+    fun `fetchDefaultRiScDescriptors does not fetch riscs when ids are wrong`() =
+        runTest {
+            val airTableClientService = spyk<AirTableClientService>()
+            mockkObject(DefaultRiScTypeUtils)
+
+            coEvery {
+                airTableClientService.fetchDefaultRiScsFromAirTable()
+            } returns exampleAirtableFetchResponse
+            every { DefaultRiScTypeUtils.getAllRecordIds() } returns setOf("rec-does-not-exist", "rec-int")
+
+            val descriptors = airTableClientService.fetchDefaultRiScDescriptors()
+
+            assertEquals(1, descriptors.size)
+        }
+
+    @Test
+    fun `fetchDefaultRiScDescriptors sets correct risc type`() =
+        runTest {
+            val airTableClientService = spyk<AirTableClientService>()
+            mockkObject(DefaultRiScTypeUtils)
+
+            coEvery {
+                airTableClientService.fetchDefaultRiScsFromAirTable()
+            } returns exampleAirtableFetchResponse
+            every { DefaultRiScTypeUtils.getAllRecordIds() } returns setOf("rec-ops", "rec-int", "rec-sta")
+
+            val descriptors = airTableClientService.fetchDefaultRiScDescriptors()
+
+            assertEquals(3, descriptors.size)
+
+            var containsStandard = false
+            var containsInternalJob = false
+            var containsOps = false
+
+            for (descriptor in descriptors) {
+                when (descriptor.riScType) {
+                    DefaultRiScType.Standard -> containsStandard = true
+                    DefaultRiScType.InternalJob -> containsInternalJob = true
+                    DefaultRiScType.Ops -> containsOps = true
+                }
+            }
+            assertTrue(containsStandard)
+            assertTrue(containsInternalJob)
+            assertTrue(containsOps)
+        }
+
+    @Test
+    fun `fetchDefaultRiScDescriptors returns descriptors with correct values when riscs have non-null values`() =
+        runTest {
+            val airTableClientService = spyk<AirTableClientService>()
+            mockkObject(DefaultRiScTypeUtils)
+
+            coEvery {
+                airTableClientService.fetchDefaultRiScsFromAirTable()
+            } returns exampleAirtableFetchResponse
+            every { DefaultRiScTypeUtils.getAllRecordIds() } returns setOf("rec-sta")
+
+            val descriptors = airTableClientService.fetchDefaultRiScDescriptors()
+
+            assertEquals(1, descriptors.size)
+            val sD = descriptors[0]
+            assertEquals(sD.riScType, DefaultRiScType.Standard)
+            assertEquals(sD.listName, airTableRecordStandard.fields.listName)
+            assertEquals(sD.listDescription, airTableRecordStandard.fields.listDescription)
+            assertEquals(sD.defaultTitle, airTableRecordStandard.fields.defaultTitle)
+            assertEquals(sD.defaultScope, airTableRecordStandard.fields.defaultScope)
+            assertEquals(sD.numberOfActions, airTableRecordStandard.fields.numberOfActions)
+            assertEquals(sD.numberOfScenarios, airTableRecordStandard.fields.numberOfScenarios)
+        }
+
+    @Test
+    fun `fetchDefaultRiScDescriptors returns descriptors with correct values when riscs have null values`() =
+        runTest {
+            val airTableClientService = spyk<AirTableClientService>()
+            mockkObject(DefaultRiScTypeUtils)
+
+            coEvery {
+                airTableClientService.fetchDefaultRiScsFromAirTable()
+            } returns emptyAirtableFetchResponse
+            every { DefaultRiScTypeUtils.getAllRecordIds() } returns setOf("rec-sta")
+
+            val descriptors = airTableClientService.fetchDefaultRiScDescriptors()
+
+            assertEquals(1, descriptors.size)
+            val eD = descriptors[0]
+            assertEquals(eD.riScType, DefaultRiScType.Standard)
+            assertEquals(eD.listName, "Unknown name")
+            assertEquals(eD.listDescription, "Unknown description")
+            assertEquals(eD.defaultTitle, "")
+            assertEquals(eD.defaultScope, "")
+            assertEquals(eD.numberOfActions, null)
+            assertEquals(eD.numberOfScenarios, null)
+        }
+}

--- a/src/test/kotlin/kartverket/no/generate/GenerateRiScRoutesTest.kt
+++ b/src/test/kotlin/kartverket/no/generate/GenerateRiScRoutesTest.kt
@@ -45,7 +45,7 @@ class GenerateRiScRoutesTest {
         mockkObject(AirTableClientService)
 
         coEvery {
-            AirTableClientService.fetchDefaultRiSc(DefaultRiScType.Standard)
+            AirTableClientService.fetchDefaultRiScContent(DefaultRiScType.Standard)
         } returns
             RiScContent(
                 schemaVersion = "1.0",

--- a/src/test/kotlin/kartverket/no/generate/GenerateServiceTest.kt
+++ b/src/test/kotlin/kartverket/no/generate/GenerateServiceTest.kt
@@ -48,7 +48,7 @@ class GenerateServiceTest {
             mockkObject(AirTableClientService)
 
             coEvery {
-                AirTableClientService.fetchDefaultRiSc(DefaultRiScType.Standard)
+                AirTableClientService.fetchDefaultRiScContent(DefaultRiScType.Standard)
             } returns
                 RiScContent(
                     schemaVersion = "defaultSchema",
@@ -128,7 +128,7 @@ class GenerateServiceTest {
                 )
 
             coEvery {
-                AirTableClientService.fetchDefaultRiSc(DefaultRiScType.Standard)
+                AirTableClientService.fetchDefaultRiScContent(DefaultRiScType.Standard)
             } returns
                 RiScContent(
                     schemaVersion = "defaultSchema",
@@ -193,7 +193,7 @@ class GenerateServiceTest {
                 )
 
             coEvery {
-                AirTableClientService.fetchDefaultRiSc(DefaultRiScType.Ops)
+                AirTableClientService.fetchDefaultRiScContent(DefaultRiScType.Ops)
             } returns
                 RiScContent(
                     schemaVersion = "defaultSchema",
@@ -257,7 +257,7 @@ class GenerateServiceTest {
                 )
 
             coEvery {
-                AirTableClientService.fetchDefaultRiSc(DefaultRiScType.InternalJob)
+                AirTableClientService.fetchDefaultRiScContent(DefaultRiScType.InternalJob)
             } returns
                 RiScContent(
                     schemaVersion = "defaultSchema",

--- a/src/test/kotlin/kartverket/no/utils/ValidatorsTest.kt
+++ b/src/test/kotlin/kartverket/no/utils/ValidatorsTest.kt
@@ -1,9 +1,8 @@
-package kartverket.no.generate.utils
+package kartverket.no.utils
 
 import io.ktor.server.plugins.requestvalidation.ValidationResult
 import kartverket.no.generate.model.DefaultRiScType
 import kartverket.no.generate.model.GenerateRiScRequestBody
-import kartverket.no.utils.Validators
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue


### PR DESCRIPTION
# Fetching data about default RiScs from Airtable
This data is automatically fetched from airtable:
<img width="220" height="170" alt="image" src="https://github.com/user-attachments/assets/444baf56-da5b-4da9-86bd-73c0c369c311" />

# Changed flow of create risc form
Instead of defining title and scope before the type of default RiSc, the type of default RiSc is defined first.
<img width="527" height="79" alt="image" src="https://github.com/user-attachments/assets/9113796c-8549-4b7e-bb57-c219c03bd0d1" />


# Auto-fill title and scope based on selected default RiSc
When selecting a default RiSc type, the title and scope is auto-filled according to airtable. In the example below, the initial RiSc "Build and Deploy" was selected.
<img width="665" height="623" alt="image" src="https://github.com/user-attachments/assets/4ad8c9af-cc0b-441e-a97f-56e6e90aee1c" />

